### PR TITLE
Make the tests fail when results don't match (Issue #19)

### DIFF
--- a/tests/SIMDArray.Tests/Test.fs
+++ b/tests/SIMDArray.Tests/Test.fs
@@ -19,9 +19,8 @@ let inline horizontal (f : ^T -> ^T -> ^T) (v :Vector< ^T>) : ^T =
 let inline compareNums a b =
     let fa = float a
     let fb = float b
-    a.Equals b || float(a - b) < 0.00001 || float(b -  a) < 0.00001 ||
+    a.Equals b || abs(float(a - b)) < 0.00001 ||
     Double.IsNaN fa && Double.IsInfinity fb || Double.IsNaN fb && Double.IsInfinity fa
-
 
 let inline areEqual (xs: 'T []) (ys: 'T []) =
     match xs, ys with
@@ -53,7 +52,7 @@ let arrayArb<'a> =
 
 let testCount = 10000
 let config = 
-    { Config.Quick with 
+    { Config.QuickThrowOnFailure with 
         MaxTest = testCount
         StartSize = 1
     }
@@ -561,13 +560,7 @@ let ``SIMD.min = Array.min`` () =
     fun (array: float []) ->
         (array.Length > 0 && array <> [||]) ==>
         lazy (compareNums (Array.SIMD.min array) (Array.min array))
-
-[<Test>]                  
-let ``SIMD.dot`` () =
-    let xs  = [|1..100|]
-    let xs2 = [|2..101|]
-    Assert.AreEqual((Array.fold2 (fun a x y -> a + x*y) 0 xs xs2), (Array.SIMD.dot xs xs2))
-
+    
 [<Test>]                  
 let ``SIMD.dot = multiply and sum`` () =
     quickCheck <|


### PR DESCRIPTION
The floating-point comparisons always passed because ``(a-b)<smallvalue || (b-a)<smallvalue`` is always true. Also, the test count was too high for some of the simpler tests, so FsCheck couldn't generate enough input sets.

This pull request causes the tests for minBy and maxBy to fail. I've added two simpler tests to demonstrate why, and I'll create a separate issue because it's not a simple fix (at least not simple enough that I can immediately see the solution :-)